### PR TITLE
Remove unnecessary log messages for jump height

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -206,7 +206,6 @@ Flight = {
 					player:set_physics_override({ jump = newjump })
 					armor.def[flight.player:get_player_name()].jump = newjump
 					flight.applied_jump = true
-					minetest.log("applied jump " .. flight.wing.jump)
 				end
 			end,
 
@@ -219,7 +218,6 @@ Flight = {
 					player:set_physics_override({ jump = newjump })
 					armor.def[flight.player:get_player_name()].jump = newjump
 					flight.applied_jump = false
-					minetest.log("removed jump " .. flight.wing.jump)
 				end
 			end,
 


### PR DESCRIPTION
Log statements used for debugging the latest changes were mistakenly left in the non-player_monoids logic for applying jump height. This change removes the unnecessary log statements.