### PR TITLE
Update Esperanto translation

### DIFF
--- a/locale/aerial.eo.tr
+++ b/locale/aerial.eo.tr
@@ -1,7 +1,7 @@
 # textdomain: aerial
-Wooden Wings=Lignaj Flugiloj
-Cactus Wings=Kaktaj Flugiloj
-Bronze Wings=Bronzaj Flugiloj
-Steel Wings=Ŝtalaj Flugiloj
-Golden Wings=Oraj Flugiloj
-Diamond Wings=Diamantaj Flugiloj
+Wooden Wings=Lignaj flugiloj
+Cactus Wings=Kaktaj flugiloj
+Bronze Wings=Bronzaj flugiloj
+Steel Wings=Ŝtalaj flugiloj
+Golden Wings=Oraj flugiloj
+Diamond Wings=Diamantaj flugiloj


### PR DESCRIPTION
Sorry to send in another patch, but Minetest game’s Esperanto translation was recently updated to use different capitalization for item-names; this tweaks item names’ capitalization to match it. ^ ^